### PR TITLE
Various small changes, including a breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Contains useful extension methods and helper functions for Monogame/XNA
 
 ## Tourmi.Aseprite
 Models for Serialization/deserialization of Aseprite json data
+- For Spritesheet exports in version 1.3 of Aseprite

--- a/Tourmi.Framework.sln
+++ b/Tourmi.Framework.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.9.34723.18
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4D1A2EF6-3C20-4C39-AF5E-E0E834DEF340}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_SolutionItems", "_SolutionItems", "{4D1A2EF6-3C20-4C39-AF5E-E0E834DEF340}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
@@ -38,13 +38,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\createRelease.yml = .github\workflows\createRelease.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monogame", "src\Monogame\Monogame.csproj", "{5AF32252-AAAD-46AC-B2FC-DF75530BDC25}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monogame", "src\Monogame\Monogame.csproj", "{5AF32252-AAAD-46AC-B2FC-DF75530BDC25}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monogame.UnitTests", "tests\Monogame.UnitTests\Monogame.UnitTests.csproj", "{6398D88A-4276-4EAF-A300-279AF8F1A646}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Monogame.UnitTests", "tests\Monogame.UnitTests\Monogame.UnitTests.csproj", "{6398D88A-4276-4EAF-A300-279AF8F1A646}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aseprite", "src\Aseprite\Aseprite.csproj", "{D9D3A100-D9FA-4FD4-8FBC-B38AC26E96AE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aseprite", "src\Aseprite\Aseprite.csproj", "{D9D3A100-D9FA-4FD4-8FBC-B38AC26E96AE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aseprite.UnitTests", "tests\Aseprite.UnitTests\Aseprite.UnitTests.csproj", "{5D1D623B-CCF6-4820-9244-CF4651283087}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aseprite.UnitTests", "tests\Aseprite.UnitTests\Aseprite.UnitTests.csproj", "{5D1D623B-CCF6-4820-9244-CF4651283087}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Aseprite", "Aseprite", "{8EF698E3-1BCB-417F-98FC-DE658F393669}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Monogame", "Monogame", "{690255EA-BCFD-44CB-B6F1-386DE421526D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -85,6 +89,10 @@ Global
 		{3AAC582D-BA17-46AD-B312-5AC7B9B3F0A5} = {4D1A2EF6-3C20-4C39-AF5E-E0E834DEF340}
 		{73CDA76D-ECB5-4F8B-9378-77B38D5205AF} = {4D1A2EF6-3C20-4C39-AF5E-E0E834DEF340}
 		{C06215A5-5DCA-4586-A570-457C6BE6C1CC} = {73CDA76D-ECB5-4F8B-9378-77B38D5205AF}
+		{5AF32252-AAAD-46AC-B2FC-DF75530BDC25} = {690255EA-BCFD-44CB-B6F1-386DE421526D}
+		{6398D88A-4276-4EAF-A300-279AF8F1A646} = {690255EA-BCFD-44CB-B6F1-386DE421526D}
+		{D9D3A100-D9FA-4FD4-8FBC-B38AC26E96AE} = {8EF698E3-1BCB-417F-98FC-DE658F393669}
+		{5D1D623B-CCF6-4820-9244-CF4651283087} = {8EF698E3-1BCB-417F-98FC-DE658F393669}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {081AF8C9-E423-4323-834C-3A1D794E4380}

--- a/src/Aseprite/Models/AnimationFrame.cs
+++ b/src/Aseprite/Models/AnimationFrame.cs
@@ -4,7 +4,7 @@ namespace Tourmi.RLMV.Aseprite;
 /// <summary>
 /// Represents a single animation frame.
 /// </summary>
-public class AsepriteFrame
+public class AnimationFrame
 {
     /// <summary>
     /// Custom name for this frame
@@ -13,7 +13,7 @@ public class AsepriteFrame
     /// <summary>
     /// The zone on the original texture image to render for this frame.
     /// </summary>
-    public AsepriteRectangle Frame { get; set; }
+    public Rectangle Frame { get; set; }
     /// <summary>
     /// Whether or not this frame is rotated.
     /// </summary>
@@ -22,6 +22,14 @@ public class AsepriteFrame
     /// Whether or not this frame was trimmed
     /// </summary>
     public bool Trimmed { get; set; }
+    /// <summary>
+    /// The sprite's source size, usage unknown
+    /// </summary>
+    public Rectangle SpriteSourceSize { get; set; }
+    /// <summary>
+    /// The frame's source size? Usage unknown
+    /// </summary>
+    public Rectangle SourceSize { get; set; }
     /// <summary>
     /// Frame duration in miliseconds 
     /// </summary>

--- a/src/Aseprite/Models/FrameTag.cs
+++ b/src/Aseprite/Models/FrameTag.cs
@@ -4,7 +4,7 @@ namespace Tourmi.RLMV.Aseprite;
 /// <summary>
 /// Metadata for an individual animation in the sprite
 /// </summary>
-public class AsepriteFrameTag
+public class FrameTag
 {
     /// <summary>
     /// Name for the animation
@@ -22,6 +22,10 @@ public class AsepriteFrameTag
     /// The direction to read the animation in. Possible values: forward, backward, ping-pong
     /// </summary>
     public string Direction { get; set; }
+    /// <summary>
+    /// Color of the frame as an hexadecimal string. ie: #fe5b59ff
+    /// </summary>
+    public string Color { get; set; }
     /// <summary>
     /// Additional data defined in the tag
     /// </summary>

--- a/src/Aseprite/Models/Meta.cs
+++ b/src/Aseprite/Models/Meta.cs
@@ -6,7 +6,7 @@ namespace Tourmi.RLMV.Aseprite;
 /// <summary>
 /// Meta data for the Sprite
 /// </summary>
-public class AsepriteMeta
+public class Meta
 {
     /// <summary>
     /// Version sprite was exported with
@@ -17,11 +17,19 @@ public class AsepriteMeta
     /// </summary>
     public string Image { get; set; }
     /// <summary>
+    /// Image format string for the sprite
+    /// </summary>
+    public string Format { get; set; }
+    /// <summary>
     /// Size of the image file
     /// </summary>
-    public AsepriteRectangle Size { get; set; }
+    public Rectangle Size { get; set; }
+    /// <summary>
+    /// Scale string
+    /// </summary>
+    public string Scale { get; set; }
     /// <summary>
     /// Frame tags of the sprite
     /// </summary>
-    public AsepriteFrameTag[] FrameTags { get; set; }
+    public FrameTag[] FrameTags { get; set; }
 }

--- a/src/Aseprite/Models/Rectangle.cs
+++ b/src/Aseprite/Models/Rectangle.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Data structure used by Aseprite representing a Rectangle. 
 /// </summary>
-public class AsepriteRectangle
+public class Rectangle
 {
     /// <summary>
     /// X location

--- a/src/Aseprite/Models/Sprite.cs
+++ b/src/Aseprite/Models/Sprite.cs
@@ -6,15 +6,15 @@ namespace Tourmi.RLMV.Aseprite;
 /// <summary>
 /// Class representing a single aseprite export.
 /// </summary>
-public class AsepriteSprite
+public class Sprite
 {
     /// <summary>
     /// All the animation frames for this sprite
     /// </summary>
-    public AsepriteFrame[] Frames { get; set; }
+    public AnimationFrame[] Frames { get; set; }
 
     /// <summary>
     /// Metadata for this sprite
     /// </summary>
-    public AsepriteMeta Meta { get; set; }
+    public Meta Meta { get; set; }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,5 +23,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="True" PackagePath="\" />
+    <None Include="..\..\LICENSE" Pack="True" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/Framework/Extensions/EnumerableExtensions.cs
+++ b/src/Framework/Extensions/EnumerableExtensions.cs
@@ -12,6 +12,6 @@ public static class EnumerableExtensions
     /// <param name="enumerable">The enumerable to order randomly</param>
     /// <param name="random">The random source</param>
     /// <returns>The randomly ordered enumerable</returns>
-    public static IOrderedEnumerable<T> OrderByRandom<T>(this IEnumerable<T> enumerable, Random random)
+    public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> enumerable, Random random)
         => enumerable.OrderBy(_ => random.Next());
 }

--- a/src/Framework/Extensions/RandomExtensions.cs
+++ b/src/Framework/Extensions/RandomExtensions.cs
@@ -16,9 +16,9 @@ public static class RandomExtensions
         => collection.ThrowIfNullOrEmpty().ElementAt(random.ThrowIfNull().Next(collection.Count));
 
     /// <summary>
-    /// Returns <paramref name="amount"/> random elements from the given <paramref name="collection"/>
+    /// Picks <paramref name="amount"/> random elements from the given <paramref name="collection"/>
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">Type of the items in the collection</typeparam>
     /// <param name="random">Random source, called up to N times, where N is the amount of items in <paramref name="collection"/></param>
     /// <param name="collection">The collection to take from</param>
     /// <param name="amount">The amount to take from the collection</param>

--- a/src/Monogame/Extensions/DictionaryWithPointKeyExtensions.cs
+++ b/src/Monogame/Extensions/DictionaryWithPointKeyExtensions.cs
@@ -5,7 +5,6 @@
 /// </summary>
 public static class DictionaryWithPointKeyExtensions
 {
-
     /// <summary>
     /// Returns a subset of a <see cref="Dictionary{TKey, TValue}"/> with a <see cref="Point"/> Key. 
     /// <para/>The subset returned will have all the keys contained within the given <paramref name="subsetBounds"/>, 

--- a/src/Monogame/Extensions/Vector2Extensions.cs
+++ b/src/Monogame/Extensions/Vector2Extensions.cs
@@ -37,7 +37,7 @@ public static class Vector2Extensions
     /// Rotates the Vector by the specified angle.
     /// </summary>
     /// <param name="v">This vector</param>
-    /// <param name="angle">should be between -1 to 1</param>
+    /// <param name="angle">should be between a number between -1 and 1, where 1 represents a full rotation</param>
     public static Vector2 Rotate(this Vector2 v, float angle)
     {
         angle *= MathHelper.Tau;
@@ -45,7 +45,7 @@ public static class Vector2Extensions
     }
 
     /// <summary>
-    /// Returns the angle of the vector, as a value between 0 to 1, 0 being an angle pointing right
+    /// Returns the angle of the vector, as a value between 0 to 1, 0 being an angle pointing towards positive X
     /// </summary>
     public static float Angle01(this Vector2 v)
     {

--- a/src/Monogame/Extensions/VectorReconstructingExtensions.cs
+++ b/src/Monogame/Extensions/VectorReconstructingExtensions.cs
@@ -93,6 +93,11 @@ public static class VectorReconstructingExtensions
     public static Vector3 WithXYZ(this Vector2 v, Vector2 xy, float z) => Create(xy, z);
     public static Vector3 WithXYZ(this Vector2 v, float x, Vector2 yz) => Create(x, yz);
     public static Vector3 WithXYZ(this Vector2 v, Vector3 xyz) => xyz;
+    public static Vector4 WithXZW(this Vector2 v, float x, float z, float w) => Create(x, v.Y(), z, w);
+    public static Vector4 WithXZW(this Vector2 v, float xzw) => Create(xzw, v.Y(), xzw, xzw);
+    public static Vector4 WithXZW(this Vector2 v, Vector2 xz, float w) => Create(xz.X(), v.Y(), xz.Y(), w);
+    public static Vector4 WithXZW(this Vector2 v, float x, Vector2 zw) => Create(x, v.Y(), zw.XY());
+    public static Vector4 WithXZW(this Vector2 v, Vector3 xzw) => Create(xzw.X(), v.Y(), xzw.YZ());
     public static Vector4 WithYZW(this Vector2 v, float y, float z, float w) => Create(v.X(), y, z, w);
     public static Vector4 WithYZW(this Vector2 v, float yzw) => Create(v.X(), yzw.XXX());
     public static Vector4 WithYZW(this Vector2 v, Vector2 yz, float w) => Create(v.X(), yz, w);
@@ -108,6 +113,11 @@ public static class VectorReconstructingExtensions
     public static Vector4 WithXYW(this Vector3 v, Vector2 xy, float w) => Create(xy, v.Z(), w);
     public static Vector4 WithXYW(this Vector3 v, float x, Vector2 yw) => Create(x, yw.X(), v.Z(), yw.Y());
     public static Vector4 WithXYW(this Vector3 v, Vector3 xyw) => Create(xyw.XY(), v.Z(), xyw.Z());
+    public static Vector4 WithXZW(this Vector3 v, float x, float z, float w) => Create(x, v.Y(), z, w);
+    public static Vector4 WithXZW(this Vector3 v, float xzw) => Create(xzw, v.Y(), xzw, xzw);
+    public static Vector4 WithXZW(this Vector3 v, Vector2 xz, float w) => Create(xz.X(), v.Y(), xz.Y(), w);
+    public static Vector4 WithXZW(this Vector3 v, float x, Vector2 zw) => Create(x, v.Y(), zw.XY());
+    public static Vector4 WithXZW(this Vector3 v, Vector3 xzw) => Create(xzw.X(), v.Y(), xzw.YZ());
     public static Vector4 WithYZW(this Vector3 v, float y, float z, float w) => Create(v.X(), y, z, w);
     public static Vector4 WithYZW(this Vector3 v, float yzw) => Create(v.X(), yzw.XXX());
     public static Vector4 WithYZW(this Vector3 v, Vector2 yz, float w) => Create(v.X(), yz, w);
@@ -123,6 +133,11 @@ public static class VectorReconstructingExtensions
     public static Vector4 WithXYW(this Vector4 v, Vector2 xy, float w) => Create(xy, v.Z(), w);
     public static Vector4 WithXYW(this Vector4 v, float x, Vector2 yw) => Create(x, yw.X(), v.Z(), yw.Y());
     public static Vector4 WithXYW(this Vector4 v, Vector3 xyw) => Create(xyw.XY(), v.Z(), xyw.Z());
+    public static Vector4 WithXZW(this Vector4 v, float x, float z, float w) => Create(x, v.Y(), z, w);
+    public static Vector4 WithXZW(this Vector4 v, float xzw) => Create(xzw, v.Y(), xzw, xzw);
+    public static Vector4 WithXZW(this Vector4 v, Vector2 xz, float w) => Create(xz.X(), v.Y(), xz.Y(), w);
+    public static Vector4 WithXZW(this Vector4 v, float x, Vector2 zw) => Create(x, v.Y(), zw.XY());
+    public static Vector4 WithXZW(this Vector4 v, Vector3 xzw) => Create(xzw.X(), v.Y(), xzw.YZ());
     public static Vector4 WithYZW(this Vector4 v, float y, float z, float w) => Create(v.X(), y, z, w);
     public static Vector4 WithYZW(this Vector4 v, float yzw) => Create(v.X(), yzw.XXX());
     public static Vector4 WithYZW(this Vector4 v, Vector2 yz, float w) => Create(v.X(), yz, w);

--- a/src/Monogame/Helpers/Rectangles.cs
+++ b/src/Monogame/Helpers/Rectangles.cs
@@ -8,16 +8,15 @@ public static class Rectangles
     /// <summary>
     /// Returns the bounding <see cref="Rectangle"/> with the given <paramref name="position"/>, <paramref name="offset"/> and <paramref name="size"/>
     /// </summary>
-    /// <returns>Returns the bounding <see cref="Rectangle"/> of the <paramref name="position"/> and <paramref name="size"/></returns>
     public static Rectangle GetBoundingRectangle(Vector2 position, Vector2 offset, Vector2 size)
-    {
-        var realPos = position + offset;
-        var aabb = new Rectangle(
-            (int)Math.Floor(realPos.X),
-            (int)Math.Floor(realPos.Y),
-            (int)Math.Ceiling(Math.Ceiling(realPos.X + size.X) - realPos.X),
-            (int)Math.Ceiling(Math.Ceiling(realPos.Y + size.Y) - realPos.Y));
+        => GetBoundingRectangle(position + offset, size);
 
-        return aabb;
-    }
+    /// <summary>
+    /// Returns the bounding <see cref="Rectangle"/> with the given <paramref name="position"/> and <paramref name="size"/>.
+    /// </summary>
+    public static Rectangle GetBoundingRectangle(Vector2 position, Vector2 size) => new(
+            (int)Math.Floor(position.X),
+            (int)Math.Floor(position.Y),
+            (int)Math.Ceiling(Math.Ceiling(position.X + size.X) - position.X),
+            (int)Math.Ceiling(Math.Ceiling(position.Y + size.Y) - position.Y));
 }

--- a/src/Monogame/Helpers/Vectors.cs
+++ b/src/Monogame/Helpers/Vectors.cs
@@ -1,20 +1,42 @@
-﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-namespace Tourmi.Monogame.Helpers;
+﻿namespace Tourmi.Monogame.Helpers;
 
 /// <summary>
 /// Helper class for XNA vectors
 /// </summary>
 public static class Vectors
 {
+    /// <summary>
+    /// Creates a new Vector using the specified components
+    /// </summary>
     public static Vector2 Create(float x, float y) => new(x, y);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector3 Create(float x, float y, float z) => new(x, y, z);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector3 Create(Vector2 xy, float z) => new(xy, z);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector3 Create(float x, Vector2 yz) => new(x, yz.X, yz.Y);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector4 Create(float x, float y, float z, float w) => new(x, y, z, w);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector4 Create(Vector2 xy, float z, float w) => new(xy, z, w);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector4 Create(float x, Vector2 yz, float w) => new(x, yz.X, yz.Y, w);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector4 Create(float x, float y, Vector2 zw) => new(x, y, zw.X, zw.Y);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector4 Create(Vector2 xy, Vector2 zw) => new(xy, zw.X, zw.Y);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector4 Create(Vector3 xyz, float w) => new(xyz, w);
+
+    /// <inheritdoc cref="Create(float, float)"/>
     public static Vector4 Create(float x, Vector3 yzw) => new(x, yzw.X, yzw.Y, yzw.Z);
 }

--- a/src/Monogame/Rendering/DebugDrawShapes.cs
+++ b/src/Monogame/Rendering/DebugDrawShapes.cs
@@ -6,7 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 namespace Tourmi.Monogame.Rendering;
 
 /// <summary>
-/// Shape drawing utility. Should only be used for debugging.
+/// Shape drawing utility. 
+/// Should only be used for debugging, as these functions are extremely inefficient. 
+/// The Texture2D `whitePixel` needs to be a 1x1 white pixel.
 /// </summary>
 [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Debug utilities, no need for validation")]
 public static class DebugDrawShapes

--- a/tests/Framework.UnitTests/Extensions/EnumerableExtensionsTests.cs
+++ b/tests/Framework.UnitTests/Extensions/EnumerableExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Framework.Extensions;
 
 [TestFixture(TestOf = typeof(EnumerableExtensions))]
-internal class EnumerableExtensionsUnitTests
+internal class EnumerableExtensionsTests
 {
     private Random? _random;
     private IEnumerable<int>? _collection;
@@ -19,7 +19,7 @@ internal class EnumerableExtensionsUnitTests
     [Test]
     public void OrderByRandomReturnsRandomEnumerable()
     {
-        var actual = Collection.OrderByRandom(Random).ToList();
+        var actual = Collection.OrderBy(Random).ToList();
 
         Assert.That(actual, Is.EquivalentTo(Collection));
         Assert.That(actual, Is.Not.EqualTo(Collection));

--- a/tests/Framework.UnitTests/Extensions/NumberExtensionsTests.cs
+++ b/tests/Framework.UnitTests/Extensions/NumberExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Framework.Extensions;
 
 [TestFixture(TestOf = typeof(NumberExtensions))]
-internal class NumberExtensionsUnitTests
+internal class NumberExtensionsTests
 {
     [Test]
     [TestCase(-5, 3, 1)]

--- a/tests/Framework.UnitTests/Extensions/RandomExtensionsTests.cs
+++ b/tests/Framework.UnitTests/Extensions/RandomExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Framework.Extensions;
 
 [TestFixture(TestOf = typeof(RandomExtensions))]
-internal class RandomExtensionsUnitTests
+internal class RandomExtensionsTests
 {
     private Random? _random;
     private Random Random => _random.ThrowIfNull();

--- a/tests/Framework.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/tests/Framework.UnitTests/Extensions/StringExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Framework.Extensions;
 
 [TestFixture(TestOf = typeof(StringExtensions))]
-internal class StringExtensionsUnitTests
+internal class StringExtensionsTests
 {
     [Test]
     [TestCase("value1", "value1")]

--- a/tests/Framework.UnitTests/ServiceProviders/ServiceProviderExtensionsTests.cs
+++ b/tests/Framework.UnitTests/ServiceProviders/ServiceProviderExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Framework.ServiceProviders;
 
 [TestFixture(TestOf = typeof(ServiceProviderExtensions))]
-internal class ServiceProviderExtensionsUnitTests
+internal class ServiceProviderExtensionsTests
 {
     private ServiceProvider? _serviceProvider;
     private ServiceProvider ServiceProvider => _serviceProvider.ThrowIfNull();

--- a/tests/Framework.UnitTests/ServiceProviders/ServiceProviderTests.cs
+++ b/tests/Framework.UnitTests/ServiceProviders/ServiceProviderTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Framework.ServiceProviders;
 
 [TestFixture(TestOf = typeof(ServiceProvider))]
-internal class ServiceProviderUnitTests
+internal class ServiceProviderTests
 {
     private ServiceProvider? _serviceProvider;
     private ServiceProvider ServiceProvider => _serviceProvider.ThrowIfNull();

--- a/tests/Monogame.UnitTests/Extensions/DictionaryWithPointKeyExtensionsTests.cs
+++ b/tests/Monogame.UnitTests/Extensions/DictionaryWithPointKeyExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Monogame.Extensions;
 
 [TestFixture(TestOf = typeof(DictionaryWithPointKeyExtensions))]
-internal class DictionaryWithPointKeyExtensionsUnitTests
+internal class DictionaryWithPointKeyExtensionsTests
 {
     [Test]
     public void SubsetTest()

--- a/tests/Monogame.UnitTests/Extensions/RectangleExtensionsTests.cs
+++ b/tests/Monogame.UnitTests/Extensions/RectangleExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tourmi.Monogame.Extensions;
 
 [TestFixture(TestOf = typeof(RectangleExtensions))]
-internal class RectangleExtensionsUnitTests
+internal class RectangleExtensionsTests
 {
     public static object[][] RectangleMultiplyTestSource =
     [

--- a/tests/Monogame.UnitTests/Extensions/VectorReconstructingExtensionsComponentPickerTests.cs
+++ b/tests/Monogame.UnitTests/Extensions/VectorReconstructingExtensionsComponentPickerTests.cs
@@ -1,0 +1,172 @@
+﻿using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Tourmi.Monogame.Extensions;
+
+[TestFixture(TestOf = typeof(VectorReconstructingExtensions))]
+internal partial class VectorReconstructingExtensionsComponentPickerTests
+{
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            foreach (var combination in GetComponentCombinations())
+            {
+                if (combination.Length == 0)
+                {
+                    continue;
+                }
+
+                for (var initialValueComponentCount = 1; initialValueComponentCount <= 4; initialValueComponentCount++)
+                {
+                    if (combination.Any(c => c >= initialValueComponentCount))
+                    {
+                        continue;
+                    }
+
+                    yield return new ComponentPickerTestCase(GetInitialValues(initialValueComponentCount), combination);
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<int[]> GetComponentCombinations(int countLeft = 4)
+    {
+        if (countLeft <= 0)
+        {
+            yield break;
+        }
+
+        for (var i = 0; i < 4; i++)
+        {
+            yield return [i];
+
+            foreach (var subcombination in GetComponentCombinations(countLeft - 1))
+            {
+                yield return [i, .. subcombination];
+            }
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void MethodExists(ComponentPickerTestCase testCase)
+    {
+        Assert.That(testCase.MethodExists());
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void MethodReturnsExpectedValue(ComponentPickerTestCase testCase)
+    {
+        Assert.That(testCase.Actual(), Is.EqualTo(testCase.Expected()));
+    }
+
+    [Test]
+    public void AreAllMethodsCovered()
+    {
+        var coveredFunctions = TestCases.Select(tc => (ComponentPickerTestCase)tc.Arguments[0]!).Select(t => t.GetMethodOrDefault()).ToHashSet();
+        var actualMethods = typeof(VectorReconstructingExtensions).GetMethods().Where(m => ValidFunctionNameRegex().IsMatch(m.Name)).ToHashSet();
+
+        Assert.That(coveredFunctions, Is.EquivalentTo(actualMethods));
+    }
+
+    private static Type GetTypeFromComponentCount(int componentCount) => componentCount switch
+    {
+        1 => typeof(float),
+        2 => typeof(Vector2),
+        3 => typeof(Vector3),
+        4 => typeof(Vector4),
+        _ => throw new ArgumentOutOfRangeException(nameof(componentCount)),
+    };
+
+    private static float[] GetInitialValues(int count)
+        => Enumerable.Range(10, count).Select(value => (value % 2 == 0 ? value : -value) * 1.5f).ToArray();
+
+    private static string GetComponentNameFromIndex(int index) => index switch
+    {
+        0 => "X",
+        1 => "Y",
+        2 => "Z",
+        3 => "W",
+        _ => throw new ArgumentOutOfRangeException(nameof(index)),
+    };
+
+    private static object ToVector(float[] values) => values.Length switch
+    {
+        1 => values[0],
+        2 => new Vector2(values[0], values[1]),
+        3 => new Vector3(values[0], values[1], values[2]),
+        4 => new Vector4(values[0], values[1], values[2], values[3]),
+        _ => throw new InvalidOperationException(),
+    };
+
+    internal class ComponentPickerTestCase(float[] componentValues, int[] pickedComponentIndexes)
+    {
+        private readonly float[] _componentValues = componentValues;
+        private readonly int[] _pickedComponentIndexes = pickedComponentIndexes;
+
+        public static implicit operator TestCaseData(ComponentPickerTestCase testCase) =>
+            new TestCaseData(testCase).SetArgDisplayNames($"{ToVector(testCase._componentValues)}" + $".{testCase.GetMethodName()}()");
+
+        public MethodInfo? GetMethodOrDefault()
+        {
+            var methodName = GetMethodName();
+            var returnType = GetMethodReturnType();
+            var parameterType = GetMethodParameterType();
+            return typeof(VectorReconstructingExtensions)
+                .GetMethods()
+                .Where(m => m.Name == methodName)
+                .Where(m => m.ReturnType == returnType)
+                .Where(m => m.GetParameters().Select(p => p.ParameterType).Single().Equals(parameterType))
+                .SingleOrDefault();
+        }
+
+        public bool MethodExists() => GetMethodOrDefault() != null;
+
+        public object Actual()
+        {
+            var method = GetMethodOrDefault() ?? throw new InvalidOperationException();
+
+            return method.Invoke(null, [GetMethodParameter()])!;
+        }
+
+        public object Expected()
+        {
+            var returnType = GetMethodReturnType();
+
+            if (returnType == typeof(float))
+            {
+                return _componentValues[_pickedComponentIndexes[0]];
+            }
+
+            if (returnType == typeof(Vector2))
+            {
+                return new Vector2(_componentValues[_pickedComponentIndexes[0]], _componentValues[_pickedComponentIndexes[1]]);
+            }
+
+            if (returnType == typeof(Vector3))
+            {
+                return new Vector3(_componentValues[_pickedComponentIndexes[0]], _componentValues[_pickedComponentIndexes[1]], _componentValues[_pickedComponentIndexes[2]]);
+            }
+
+            if (returnType == typeof(Vector4))
+            {
+                return new Vector4(_componentValues[_pickedComponentIndexes[0]], _componentValues[_pickedComponentIndexes[1]], _componentValues[_pickedComponentIndexes[2]], _componentValues[_pickedComponentIndexes[3]]);
+            }
+
+            throw new InvalidOperationException();
+        }
+
+        private object GetMethodParameter() => ToVector(_componentValues);
+
+        private string GetMethodName() => $"{string.Join(null, _pickedComponentIndexes.Select(GetComponentNameFromIndex))}";
+
+        private Type GetMethodReturnType() => GetTypeFromComponentCount(_pickedComponentIndexes.Length);
+
+        private Type GetMethodParameterType() => GetMethodParameter().GetType();
+    }
+
+    [GeneratedRegex("^[XYZW]{1,4}$")]
+    private static partial Regex ValidFunctionNameRegex();
+}

--- a/tests/Monogame.UnitTests/Extensions/VectorReconstructingExtensionsWithComponentTests.cs
+++ b/tests/Monogame.UnitTests/Extensions/VectorReconstructingExtensionsWithComponentTests.cs
@@ -1,0 +1,261 @@
+﻿using System.Reflection;
+
+namespace Tourmi.Monogame.Extensions;
+
+[TestFixture(TestOf = typeof(VectorReconstructingExtensions))]
+internal class VectorReconstructingExtensionsWithComponentTests
+{
+    private static readonly float[] ConstantValue = [100f];
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            for (var entryComponentCount = 1; entryComponentCount <= 4; entryComponentCount++)
+            {
+                var entryValue = GetInitialValues(entryComponentCount);
+                var combinations = GetDistinctComponentCombinations().ToArray();
+                foreach (var combination in combinations)
+                {
+                    var paramGroups = combination.ToArray();
+                    var max = paramGroups.Max(g => g.Max());
+                    var containsY = paramGroups.Any(g => g.Contains(1));
+                    var containsZ = paramGroups.Any(g => g.Contains(2));
+                    var shouldContinue = paramGroups.All(g => g.All(i =>
+                        {
+                            if (i <= entryComponentCount)
+                            {
+                                return true;
+                            }
+
+                            if (entryComponentCount <= 1 && !containsY && max > 1)
+                            {
+                                return false;
+                            }
+
+                            if (entryComponentCount <= 2 && !containsZ && max > 2)
+                            {
+                                return false;
+                            }
+
+                            return true;
+                        }));
+
+                    if (!shouldContinue || paramGroups.Length == 0 || paramGroups.Any(g => g.Length is 0))
+                    {
+                        continue;
+                    }
+
+                    var differentValuesParams = paramGroups.Select(g => (g, g.Select(i => (i + 1) * -2f).ToArray())).ToArray();
+                    yield return new WithComponentTestCase(entryValue, differentValuesParams);
+                    if (paramGroups.Length > 1)
+                    {
+                        continue;
+                    }
+                    var sameValueParams = (paramGroups[0], ConstantValue);
+                    yield return new WithComponentTestCase(entryValue, [sameValueParams]);
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<int[][]> GetDistinctComponentCombinations()
+        => GetComponentCombinations().DistinctBy(c => $"({string.Join(null, c.Select(g => $"({string.Join(null, g)})"))})");
+
+    private static IEnumerable<int[][]> GetComponentCombinations(int startIndex = 0)
+    {
+        if (startIndex >= 4)
+        {
+            yield break;
+        }
+
+        yield return [[startIndex]];
+
+        foreach (var subcombination in GetComponentCombinations(startIndex + 1))
+        {
+            yield return subcombination;
+            for (var i = 0; i < 4 - startIndex; i++)
+            {
+                yield return [[startIndex, .. subcombination.Take(i).SelectMany(c => c)], .. subcombination.Skip(i)];
+            }
+        }
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void MethodExists(WithComponentTestCase testCase)
+    {
+        Assert.That(testCase.MethodExists());
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void MethodReturnsExpectedValue(WithComponentTestCase testCase)
+    {
+        Assert.That(testCase.Actual(), Is.EqualTo(testCase.Expected()));
+    }
+
+    [Test]
+    public void AreAllMethodsCovered()
+    {
+        var coveredFunctions = TestCases.Select(tc => (WithComponentTestCase)tc.Arguments[0]!).Select(t => t.GetMethodOrDefault()).Distinct().ToHashSet();
+        var actualMethods = typeof(VectorReconstructingExtensions).GetMethods().Where(m => m.Name.StartsWith("With", StringComparison.InvariantCulture)).ToHashSet();
+
+        Assert.That(coveredFunctions, Is.EquivalentTo(actualMethods));
+    }
+
+    private static Type GetTypeFromComponentCount(int componentCount) => componentCount switch
+    {
+        1 => typeof(float),
+        2 => typeof(Vector2),
+        3 => typeof(Vector3),
+        4 => typeof(Vector4),
+        _ => throw new ArgumentOutOfRangeException(nameof(componentCount)),
+    };
+
+    private static float[] GetInitialValues(int count)
+        => Enumerable.Range(10, count).Select(value => (value % 2 == 0 ? value : -value) * 1.5f).ToArray();
+
+    private static string GetComponentNameFromIndex(int index) => index switch
+    {
+        0 => "X",
+        1 => "Y",
+        2 => "Z",
+        3 => "W",
+        _ => throw new ArgumentOutOfRangeException(nameof(index)),
+    };
+
+    private static object ToVector(float[] values) => values.Length switch
+    {
+        1 => values[0],
+        2 => new Vector2(values[0], values[1]),
+        3 => new Vector3(values[0], values[1], values[2]),
+        4 => new Vector4(values[0], values[1], values[2], values[3]),
+        _ => throw new InvalidOperationException(),
+    };
+
+    internal class WithComponentTestCase(
+        float[] entryValue,
+        (int[] Indexes, float[] Values)[] overwrittenValues)
+    {
+        private readonly float[] _entryValue = entryValue;
+        private readonly (int[] Indexes, float[] Values)[] _overwrittenValues = overwrittenValues;
+
+        public static implicit operator TestCaseData(WithComponentTestCase testCase)
+        {
+            return new TestCaseData(testCase).SetArgDisplayNames($"{ToVector(testCase._entryValue)}" +
+                $".{testCase.GetMethodName()}" +
+                $"({string.Join(", ", testCase.GetMethodParameters().Skip(1).Select(p => p.ToString()).ToArray())})");
+        }
+
+        public MethodInfo? GetMethodOrDefault()
+        {
+            var methodName = GetMethodName();
+            var returnType = GetMethodReturnType();
+            var parameterTypes = GetMethodParameterTypes().ToArray();
+            return typeof(VectorReconstructingExtensions)
+                .GetMethods()
+                .Where(m => m.Name == methodName)
+                .Where(m => m.ReturnType == returnType)
+                .Where(m => m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes))
+                .SingleOrDefault();
+        }
+
+        public bool MethodExists() => GetMethodOrDefault() != null;
+
+        public object Actual()
+        {
+            var method = GetMethodOrDefault() ?? throw new InvalidOperationException();
+
+            return method.Invoke(null, GetMethodParameters().ToArray())!;
+        }
+
+        public object Expected()
+        {
+            var returnType = GetMethodReturnType();
+
+            if (returnType == typeof(float))
+            {
+                return GetValueAt(0);
+            }
+
+            if (returnType == typeof(Vector2))
+            {
+                return new Vector2(GetValueAt(0), GetValueAt(1));
+            }
+
+            if (returnType == typeof(Vector3))
+            {
+                return new Vector3(GetValueAt(0), GetValueAt(1), GetValueAt(2));
+            }
+
+            if (returnType == typeof(Vector4))
+            {
+                return new Vector4(GetValueAt(0), GetValueAt(1), GetValueAt(2), GetValueAt(3));
+            }
+
+            throw new InvalidOperationException();
+        }
+
+        private IEnumerable<object> GetMethodParameters()
+        {
+            yield return ToVector(_entryValue);
+
+            if (_overwrittenValues.Any(v => v.Values.Length == 1 && v.Indexes.Length > 1))
+            {
+                yield return _overwrittenValues[0].Values[0];
+                yield break;
+            }
+
+            foreach (var (indexes, values) in _overwrittenValues)
+            {
+                yield return ToVector(values);
+            }
+        }
+
+        private string GetMethodName()
+        {
+            if (_overwrittenValues.Any(v => v.Values.Length == 1 && v.Indexes.Length > 1))
+            {
+                return $"With{string.Join(null, _overwrittenValues.First().Indexes.Select(GetComponentNameFromIndex))}";
+            }
+
+            var baseName = "With";
+            foreach (var (indexes, values) in _overwrittenValues)
+            {
+                foreach (var index in indexes)
+                {
+                    baseName += GetComponentNameFromIndex(index);
+                }
+            }
+
+            return baseName;
+        }
+
+        private Type GetMethodReturnType()
+        {
+            var componentCount = _overwrittenValues.Max(v => Math.Max(v.Indexes.Max() + 1, _entryValue.Length));
+
+            return GetTypeFromComponentCount(componentCount);
+        }
+
+        private IEnumerable<Type> GetMethodParameterTypes() => GetMethodParameters().Select(p => p.GetType());
+
+        private float GetValueAt(int componentIndex)
+        {
+            if (_overwrittenValues.Any(v => v.Indexes.Contains(componentIndex)))
+            {
+                if (_overwrittenValues.Any(v => v.Values.Length == 1 && v.Indexes.Length > 1))
+                {
+                    return _overwrittenValues[0].Values[0];
+                }
+
+                var (indexes, values) = _overwrittenValues.Where(v => v.Indexes!.Contains(componentIndex)).Single();
+                var index = Array.IndexOf(indexes!, componentIndex);
+                return values[index];
+            }
+
+            return _entryValue[componentIndex];
+        }
+    }
+}

--- a/tests/Monogame.UnitTests/Helpers/RectanglesTests.cs
+++ b/tests/Monogame.UnitTests/Helpers/RectanglesTests.cs
@@ -1,0 +1,50 @@
+﻿namespace Tourmi.Monogame.Helpers;
+
+[TestFixture(TestOf = typeof(Rectangles))]
+internal class RectanglesTests
+{
+    [Test]
+    public void GetBoundingRectangleReturnsWorstCaseForPosition()
+    {
+        var position = new Vector2(-1.1f, 2.9f);
+        var size = new Vector2(2f, 3f);
+
+        var actual = Rectangles.GetBoundingRectangle(position, size);
+
+        Assert.That(actual, Is.EqualTo(new Rectangle(-2, 2, 3, 4)));
+    }
+
+    [Test]
+    public void GetBoundingRectangleReturnsWorstCaseForSize()
+    {
+        var position = new Vector2(1, 1);
+        var size = new Vector2(1.1f, 2.05f);
+
+        var actual = Rectangles.GetBoundingRectangle(position, size);
+
+        Assert.That(actual, Is.EqualTo(new Rectangle(1, 1, 2, 3)));
+    }
+
+    [Test]
+    public void GetBoundingRectangleReturnsUnalteredValuesForIntegers()
+    {
+        var position = new Vector2(-1, 2);
+        var size = new Vector2(3, 4);
+
+        var actual = Rectangles.GetBoundingRectangle(position, size);
+
+        Assert.That(actual, Is.EqualTo(new Rectangle(-1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void GetBoundingRectangleWithOffsetReturnsProperValues()
+    {
+        var position = new Vector2(-1, 3);
+        var offset = new Vector2(0.1f, -0.1f);
+        var size = new Vector2(2, 3);
+
+        var actual = Rectangles.GetBoundingRectangle(position, offset, size);
+
+        Assert.That(actual, Is.EqualTo(new Rectangle(-1, 2, 3, 4)));
+    }
+}

--- a/tests/Monogame.UnitTests/Helpers/VectorsTests.cs
+++ b/tests/Monogame.UnitTests/Helpers/VectorsTests.cs
@@ -1,0 +1,51 @@
+﻿namespace Tourmi.Monogame.Helpers;
+
+[TestFixture(TestOf = typeof(Vectors))]
+internal class VectorsTests
+{
+    [Test]
+    [TestCase(-1f, 2f)]
+    [TestCase(4f, -2.54f)]
+    public void WhenCreatingVector2ItIsCreatedProperly(float x, float y)
+    {
+        var expected = new Vector2(x, y);
+
+        Assert.That(Vectors.Create(x, y), Is.EqualTo(expected));
+    }
+
+    [Test]
+    [TestCase(-1f, 2f, -3f)]
+    [TestCase(4f, -2.54f, 5.64f)]
+    public void WhenCreatingVector3ItIsCreatedProperly(float x, float y, float z)
+    {
+        var expected = new Vector3(x, y, z);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Vectors.Create(x, y, z), Is.EqualTo(expected));
+            Assert.That(Vectors.Create(new Vector2(x, y), z), Is.EqualTo(expected));
+            Assert.That(Vectors.Create(x, new Vector2(y, z)), Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    [TestCase(-1f, 2f, -3f, 4f)]
+    [TestCase(4f, -2.54f, 5.64f, -7.523f)]
+    public void WhenCreatingVector4ItIsCreatedProperly(float x, float y, float z, float w)
+    {
+        var expected = new Vector4(x, y, z, w);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Vectors.Create(x, y, z, w), Is.EqualTo(expected));
+
+            Assert.That(Vectors.Create(new Vector2(x, y), z, w), Is.EqualTo(expected));
+            Assert.That(Vectors.Create(x, new Vector2(y, z), w), Is.EqualTo(expected));
+            Assert.That(Vectors.Create(x, y, new Vector2(z, w)), Is.EqualTo(expected));
+            Assert.That(Vectors.Create(new Vector2(x, y), new Vector2(z, w)), Is.EqualTo(expected));
+
+            Assert.That(Vectors.Create(new Vector3(x, y, z), w), Is.EqualTo(expected));
+            Assert.That(Vectors.Create(x, new Vector3(y, z, w)), Is.EqualTo(expected));
+        });
+    }
+}


### PR DESCRIPTION
- OrderByRandom was renamed to OrderBy
- Added Tests for Vector functions, to ensure no errors slipped in with the hundreds of functions in VectorReconstructingExtensions
- Renamed Aseprite models
- Renamed and added tests